### PR TITLE
Fix typo in Chat service

### DIFF
--- a/views/service/chat.ejs
+++ b/views/service/chat.ejs
@@ -4,7 +4,7 @@
     and then forward them on to all <strong>other</strong> (not including the
     sender) clients.
     <br />
-    It used to power in repl chat, but doesn't anymore. Now it just powers
+    It used to power Repl chat, but doesn't anymore. Now it just powers
     multiplayer for <code>.draw</code> files.
 </p>
 


### PR DESCRIPTION
Typo: "It used to power in repl chat"